### PR TITLE
fix: Include all subpackages in PyPI distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,9 @@ Repository = "https://github.com/hspark1212/chemeleon-dng"
 Issues = "https://github.com/hspark1212/chemeleon-dng/issues"
 Documentation = "https://github.com/hspark1212/chemeleon-dng#readme"
 
-[tool.setuptools]
-# Automatically discover all packages (includes subpackages)
-# This fixes the PyPI distribution to include dataset/, diffusion/, etc.
-packages = {find = {}}
+[tool.setuptools.packages.find]
+where = ["."]  
+include = ["chemeleon_dng*"]
 
 [tool.pytest.ini_options]
 minversion = "7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chemeleon-dng"
-version = "0.1.0"
+version = "0.1.1"
 description = "Chemeleon framework for De Novo Generation (DNG) and Crystal Structure Prediction (CSP) tasks"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -42,7 +42,9 @@ Issues = "https://github.com/hspark1212/chemeleon-dng/issues"
 Documentation = "https://github.com/hspark1212/chemeleon-dng#readme"
 
 [tool.setuptools]
-packages = ["chemeleon_dng"]
+# Automatically discover all packages (includes subpackages)
+# This fixes the PyPI distribution to include dataset/, diffusion/, etc.
+packages = {find = {}}
 
 [tool.pytest.ini_options]
 minversion = "7.0"


### PR DESCRIPTION
### Problem

The current PyPI package (v0.1.0) is missing critical subpackages, causing `ModuleNotFoundError` when users install from PyPI:

```python
>>> from chemeleon_dng.dataset import MDataset
ModuleNotFoundError: No module named 'chemeleon_dng.dataset'
```

Missing packages:
- `chemeleon_dng.dataset`
- `chemeleon_dng.diffusion`
- `chemeleon_dng.diffusion.models`

### Root Cause

The `pyproject.toml` explicitly lists only the top-level package:

```toml
[tool.setuptools]
packages = ["chemeleon_dng"]
```

This prevents setuptools from including any subpackages in the distribution.

### Solution

Use automatic package discovery to include all Python packages:

```toml
[tool.setuptools]
packages = {find = {}}
```

Version bumped to `0.1.1` to supersede the broken `0.1.0` release.

### Verification

After building with the fix, the wheel now includes all subpackages:

```bash
$ python -m build
$ unzip -l dist/chemeleon_dng-0.1.1-py3-none-any.whl | grep "chemeleon_dng/"
```

Shows all expected directories: `dataset/`, `diffusion/`, and `diffusion/models/`.

### Impact

Users can now install directly from PyPI without encountering import errors.

---

### Files Changed

- `pyproject.toml`: Changed package discovery from explicit list to automatic, bumped version to 0.1.1