### PR TITLE
Add CLI entrypoint for easier command-line usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ outputs/
 
 # Distribution / packaging
 dist/
+build/

--- a/README.md
+++ b/README.md
@@ -54,10 +54,12 @@ sample(
 > [!TIP]
 > Invoke `help(sample)` to explore all available parameters and usage examples.
 
-For the command line interface, you can use the following command:
+### Command-Line Interface
+
+After installing via pip, you can use the `chemeleon-dng` command directly:
 
 ```bash
-python -m chemeleon_dng.sample --task=csp --formulas="NaCl,LiMnO2" --num_samples=10 --output_dir="results" --device=cpu
+chemeleon-dng --task=csp --formulas="NaCl,LiMnO2" --num_samples=10 --output_dir="results" --device=cpu
 ```
 
 This command generates 10 crystal structures for the given formulas using the CSP task and saves the CIF files of the generated structures in the `results/` directory using CPU.
@@ -78,10 +80,10 @@ sample(
 )
 ```
 
-For the command line interface, you can use the following command:
+For the command line interface:
 
 ```bash
-python -m chemeleon_dng.sample --task=dng --num_samples=200 --batch_size=100 --output_dir="results" --device=cuda
+chemeleon-dng --task=dng --num_samples=200 --batch_size=100 --output_dir="results" --device=cuda
 ```
 
 This command generates 200 random crystal structures using the DNG task with two batches of 100 each, and saves the generated structures in the `results/` directory using GPU.

--- a/chemeleon_dng/sample.py
+++ b/chemeleon_dng/sample.py
@@ -239,5 +239,10 @@ def sample(
         )
 
 
-if __name__ == "__main__":
+def main():
+    """CLI entry point for chemeleon-dng command."""
     fire.Fire(sample)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ Repository = "https://github.com/hspark1212/chemeleon-dng"
 Issues = "https://github.com/hspark1212/chemeleon-dng/issues"
 Documentation = "https://github.com/hspark1212/chemeleon-dng#readme"
 
+[project.scripts]
+chemeleon-dng = "chemeleon_dng.sample:main"
+
 [tool.setuptools.packages.find]
 where = ["."]  
 include = ["chemeleon_dng*"]


### PR DESCRIPTION
## Summary

- Add `[project.scripts]` entry in pyproject.toml to create `chemeleon-dng` command
- Add `main()` function in sample.py as CLI entrypoint  
- Update README.md to showcase new `chemeleon-dng` command as primary CLI method
- Add `build/` to .gitignore

## Benefits

Users can now run the CLI tool more intuitively after pip install:

**Before:**
```bash
python -m chemeleon_dng.sample --task=csp --formulas="NaCl" --num_samples=10
```

**After:**
```bash
chemeleon-dng --task=csp --formulas="NaCl" --num_samples=10
```

## Testing

Tested in a fresh virtual environment:
- ✅ Package builds successfully
- ✅ `chemeleon-dng --help` shows proper help message
- ✅ `chemeleon-dng csp --formulas=NaCl --num_samples=1 --device=cpu` runs successfully
- ✅ CLI script properly installed in `bin/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)