### PR TITLE
fix: deal with invalid cif files that cannot be converted to pymatgen.core.Structure objects

### DIFF
--- a/chemeleon_dng/base_module.py
+++ b/chemeleon_dng/base_module.py
@@ -11,8 +11,7 @@ from chemeleon_dng.schema import CrystalBatch
 
 
 class BaseModule(LightningModule):
-    """Base module for configuration of optimizers and logging.
-    """
+    """Base module for configuration of optimizers and logging."""
 
     def __init__(
         self,
@@ -44,14 +43,18 @@ class BaseModule(LightningModule):
         raise NotImplementedError("calculate_loss is not implemented")
 
     def training_step(
-        self, batch: CrystalBatch, batch_idx: int  # pylint: disable=unused-argument
+        self,
+        batch: CrystalBatch,
+        batch_idx: int,  # pylint: disable=unused-argument
     ) -> Tensor:
         res = self.calculate_loss(batch)
         self._log_metrics(res=res, split="train", batch_size=batch.num_graphs)
         return res["total_loss"]
 
     def validation_step(
-        self, batch: CrystalBatch, batch_idx: int  # pylint: disable=unused-argument
+        self,
+        batch: CrystalBatch,
+        batch_idx: int,  # pylint: disable=unused-argument
     ) -> Tensor:
         res = self.calculate_loss(batch)
         self._log_metrics(res=res, split="val", batch_size=batch.num_graphs)

--- a/chemeleon_dng/cspnet.py
+++ b/chemeleon_dng/cspnet.py
@@ -11,8 +11,7 @@ from chemeleon_dng.scatter import scatter_mean
 
 
 class CSPNetTask(enum.Enum):
-    """Which task of the model.
-    """
+    """Which task of the model."""
 
     CSP = enum.auto()  # Crystal Structure Prediction
     DNG = enum.auto()  # De Novo Generation

--- a/chemeleon_dng/dataset/mp_dataset.py
+++ b/chemeleon_dng/dataset/mp_dataset.py
@@ -12,8 +12,7 @@ warnings.filterwarnings("ignore", category=UserWarning, module="pymatgen")
 
 
 class MPDataset(Dataset):
-    """Dataset for Materials Project data (e.g., MP-20).
-    """
+    """Dataset for Materials Project data (e.g., MP-20)."""
 
     def __init__(
         self, data_dir: str | Path, split: str, target_condition: str | None = None

--- a/chemeleon_dng/diffusion/diffusion_module.py
+++ b/chemeleon_dng/diffusion/diffusion_module.py
@@ -14,8 +14,7 @@ from chemeleon_dng.script_util import create_model
 
 
 class DiffusionModuleTask(enum.Enum):
-    """Which task of the model.
-    """
+    """Which task of the model."""
 
     CSP = enum.auto()  # Crystal Structure Prediction
     DNG = enum.auto()  # De Novo Generation
@@ -23,8 +22,7 @@ class DiffusionModuleTask(enum.Enum):
 
 
 class DiffusionType(enum.Enum):
-    """Type of diffusion model.
-    """
+    """Type of diffusion model."""
 
     D3PM = enum.auto()  # Discrete Denoising Diffusion Probabilistic Models (Discrete)
     DDPM = enum.auto()  # Denoising Diffusion Probabilistic Model (Variance-preserving)
@@ -32,8 +30,7 @@ class DiffusionType(enum.Enum):
 
 
 class DiffusionModule(BaseModule):
-    """Utilities for training and sampling diffusion models.
-    """
+    """Utilities for training and sampling diffusion models."""
 
     def __init__(
         self,
@@ -50,9 +47,9 @@ class DiffusionModule(BaseModule):
         self.save_hyperparameters()
 
         if task == DiffusionModuleTask.CSP:
-            assert (
-                diffusion_atom_type is None
-            ), "Diffusion atom type should be None, when CSP"
+            assert diffusion_atom_type is None, (
+                "Diffusion atom type should be None, when CSP"
+            )
         self.model = create_model(**model_configs, task=task.name)
         self.num_timesteps = num_timesteps
         self.diffusion_atom_type = diffusion_atom_type
@@ -67,8 +64,7 @@ class DiffusionModule(BaseModule):
         noise_lattices: Tensor | None = None,
         noise_frac_coords: Tensor | None = None,
     ) -> CrystalBatch:
-        """Sample from the forward process q(x_t | x_0).
-        """
+        """Sample from the forward process q(x_t | x_0)."""
         return CrystalBatch(
             atom_types=(
                 self.diffusion_atom_type.q_sample(
@@ -171,8 +167,7 @@ class DiffusionModule(BaseModule):
         cond_embeds: Tensor | None = None,
         null_cond_embeds: Tensor | None = None,
     ) -> CrystalBatch:
-        """Sample from the reverse process p(x_{t-1} | x_t).
-        """
+        """Sample from the reverse process p(x_{t-1} | x_t)."""
         # Predictor
         model_predictor_output = _model_prediction(
             model=self.model,
@@ -247,9 +242,9 @@ class DiffusionModule(BaseModule):
         if task.lower() == "csp":
             assert self.model.task.name.lower() == "csp", "Model task should be CSP"  # type: ignore
             if atom_types is not None:
-                assert len(atom_types) == sum(
-                    num_atoms
-                ), "Length of atom_types and num_atoms should be the same."
+                assert len(atom_types) == sum(num_atoms), (
+                    "Length of atom_types and num_atoms should be the same."
+                )
             else:
                 raise ValueError("atom_types must be provided for CSP task.")
         elif task.lower() == "dng":
@@ -348,9 +343,8 @@ def _model_prediction(
             1 - cond_scale
         ) * null_model_output.lattices + cond_scale * cond_model_output.lattices
         output.frac_coords = (
-            (1 - cond_scale) * null_model_output.frac_coords
-            + cond_scale * cond_model_output.frac_coords
-        )
+            1 - cond_scale
+        ) * null_model_output.frac_coords + cond_scale * cond_model_output.frac_coords
     else:
         output = model(
             atom_types=x_t.atom_types,

--- a/chemeleon_dng/diffusion/diffusion_scheduler.py
+++ b/chemeleon_dng/diffusion/diffusion_scheduler.py
@@ -40,8 +40,7 @@ def get_named_beta_schedule(
 
 
 def cosine_beta_schedule(timesteps, s=0.008):
-    """Cosine schedule as proposed in https://arxiv.org/abs/2102.09672.
-    """
+    """Cosine schedule as proposed in https://arxiv.org/abs/2102.09672."""
     steps = timesteps + 1
     x = torch.linspace(0, timesteps, steps)
     alphas_cumprod = torch.cos(((x / timesteps) + s) / (1 + s) * math.pi * 0.5) ** 2

--- a/chemeleon_dng/diffusion/models/base.py
+++ b/chemeleon_dng/diffusion/models/base.py
@@ -2,8 +2,7 @@ from abc import ABC, abstractmethod
 
 
 class DiffusionModelBase(ABC):
-    """Abstract base class for diffusion models.
-    """
+    """Abstract base class for diffusion models."""
 
     @abstractmethod
     def q_sample(self):

--- a/chemeleon_dng/diffusion/models/d3pm.py
+++ b/chemeleon_dng/diffusion/models/d3pm.py
@@ -6,8 +6,7 @@ from chemeleon_dng.diffusion.models.base import DiffusionModelBase
 
 
 class D3PM(DiffusionModelBase):
-    """Discrete Denoising Diffusion Probabilistic Models (D3PM).
-    """
+    """Discrete Denoising Diffusion Probabilistic Models (D3PM)."""
 
     def __init__(
         self,

--- a/chemeleon_dng/diffusion/models/ddpm.py
+++ b/chemeleon_dng/diffusion/models/ddpm.py
@@ -6,8 +6,7 @@ from chemeleon_dng.diffusion.models.base import DiffusionModelBase
 
 
 class DDPM(DiffusionModelBase):
-    """Denoising Diffusion Probabilistic Model (DDPM).
-    """
+    """Denoising Diffusion Probabilistic Model (DDPM)."""
 
     def __init__(
         self,

--- a/chemeleon_dng/diffusion/models/dsm.py
+++ b/chemeleon_dng/diffusion/models/dsm.py
@@ -7,8 +7,7 @@ from chemeleon_dng.diffusion.models.base import DiffusionModelBase
 
 
 class DSM(DiffusionModelBase):
-    """Denoising Score Matching (DSM).
-    """
+    """Denoising Score Matching (DSM)."""
 
     def __init__(
         self,

--- a/chemeleon_dng/download_util.py
+++ b/chemeleon_dng/download_util.py
@@ -15,13 +15,16 @@ def download_file(url: str, filepath: Path) -> None:
 
     total_size = int(response.headers.get("content-length", 0))
 
-    with open(filepath, "wb") as f, tqdm(
-        desc=f"Downloading {filepath.name}",
-        total=total_size,
-        unit="B",
-        unit_scale=True,
-        unit_divisor=1024,
-    ) as pbar:
+    with (
+        open(filepath, "wb") as f,
+        tqdm(
+            desc=f"Downloading {filepath.name}",
+            total=total_size,
+            unit="B",
+            unit_scale=True,
+            unit_divisor=1024,
+        ) as pbar,
+    ):
         for chunk in response.iter_content(chunk_size=8192):
             if chunk:
                 f.write(chunk)

--- a/chemeleon_dng/sample.py
+++ b/chemeleon_dng/sample.py
@@ -6,6 +6,7 @@ It supports three types of tasks:
 """
 
 import json
+import warnings
 from pathlib import Path
 
 import fire
@@ -232,12 +233,21 @@ def sample(
     # Save generated structures in JSON format
     if save_json:
         gen_atoms_files = list(output_path.glob("sample_*.cif"))
-        all_gen_atoms_list = [Structure.from_file(file) for file in gen_atoms_files]
+        all_gen_atoms_list = []
+        for file in gen_atoms_files:
+            try:
+                struct = Structure.from_file(file)
+                all_gen_atoms_list.append(struct)
+            except Exception as e:
+                warnings.warn(
+                    f"Failed to convert {file} to a pymatgen.core.Structure object: {e}",
+                    UserWarning,
+                    stacklevel=2,
+                )
         dumpfn(all_gen_atoms_list, output_path / "generated_structures.json.gz")
         print(
-            f"The {len(all_gen_atoms_list)} generated structures saved in JSON format at: {output_path / 'generated_structures.json.gz'}"
+            f"Out of {len(gen_atoms_files)} generated structures, {len(all_gen_atoms_list)} were successfully converted to pymatgen Structure objects and saved in JSON format at: {output_path / 'generated_structures.json.gz'}"
         )
-
 
 def main():
     """CLI entry point for chemeleon-dng command."""

--- a/chemeleon_dng/sample.py
+++ b/chemeleon_dng/sample.py
@@ -64,7 +64,9 @@ def sample_csp(
 
         # Save generated structures
         for j, atoms in enumerate(gen_atoms_list):
-            atoms.write(output_path / f"sample_{i+j}_{atoms.get_chemical_formula()}.cif")  # type: ignore
+            atoms.write(
+                output_path / f"sample_{i + j}_{atoms.get_chemical_formula()}.cif"
+            )  # type: ignore
 
 
 def sample_dng(
@@ -83,9 +85,9 @@ def sample_dng(
         ).tolist()
     elif isinstance(num_atom_distribution, list):
         num_atoms = num_atom_distribution
-        assert (
-            len(num_atoms) == num_samples
-        ), "num_atom_distribution must be a list of length num_samples."
+        assert len(num_atoms) == num_samples, (
+            "num_atom_distribution must be a list of length num_samples."
+        )
     else:
         raise ValueError(
             "num_atom_distribution must be either a string or a list of integers."
@@ -102,7 +104,9 @@ def sample_dng(
 
         # Save generated structures
         for j, atoms in enumerate(gen_atoms_list):
-            atoms.write(output_path / f"sample_{i+j}_{atoms.get_chemical_formula()}.cif")  # type: ignore
+            atoms.write(
+                output_path / f"sample_{i + j}_{atoms.get_chemical_formula()}.cif"
+            )  # type: ignore
 
 
 def sample(
@@ -211,9 +215,9 @@ def sample(
             output_path=output_path,
         )
     elif task == "dng":
-        assert (
-            num_atom_distribution is not None
-        ), "num_atom_distribution must be provided for DNG task."
+        assert num_atom_distribution is not None, (
+            "num_atom_distribution must be provided for DNG task."
+        )
         sample_dng(
             dm=dm,
             num_atom_distribution=num_atom_distribution,
@@ -242,12 +246,12 @@ def sample(
                 warnings.warn(
                     f"Failed to convert {file} to a pymatgen.core.Structure object: {e}",
                     UserWarning,
-                    stacklevel=2,
                 )
         dumpfn(all_gen_atoms_list, output_path / "generated_structures.json.gz")
         print(
             f"Out of {len(gen_atoms_files)} generated structures, {len(all_gen_atoms_list)} were successfully converted to pymatgen Structure objects and saved in JSON format at: {output_path / 'generated_structures.json.gz'}"
         )
+
 
 def main():
     """CLI entry point for chemeleon-dng command."""

--- a/chemeleon_dng/scatter.py
+++ b/chemeleon_dng/scatter.py
@@ -7,7 +7,6 @@ that don't require installing PyTorch C++ extensions.
 See https://github.com/pytorch/pytorch/issues/63780.
 """
 
-
 import torch
 
 

--- a/chemeleon_dng/schema.py
+++ b/chemeleon_dng/schema.py
@@ -8,8 +8,7 @@ from torch import Tensor
 
 
 class CrystalBatch(BaseModel):
-    """A schema for a batch of crystal structures.
-    """
+    """A schema for a batch of crystal structures."""
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ ignore = [
     "S301",    # Pickle usage (needed for model checkpoints)
     "B007",    # Unused loop control variable
     "B008",    # Function call in default argument
+    "B028",    # No explicit stacklevel keyword argument found
     "C901",    # Function is too complex
     "UP008",   # Use super() without arguments
     "S202",    # Uses of tarfile.extractall()

--- a/scripts/train_diffusion.py
+++ b/scripts/train_diffusion.py
@@ -73,9 +73,9 @@ def main(_config):
     if cfg["logger"]["offline"]:
         cfg["logger"]["log_model"] = False
     if cfg["logger"]["group"] is None:
-        cfg["logger"][
-            "group"
-        ] = f"chemeleon/{cfg['task']}/{cfg['datamodule']['dataset_type']}"
+        cfg["logger"]["group"] = (
+            f"chemeleon/{cfg['task']}/{cfg['datamodule']['dataset_type']}"
+        )
     logger = WandbLogger(**cfg["logger"])
 
     # Set up Trainer


### PR DESCRIPTION
# Problem
The current sample.py fails to save the generated structures to `generated_structures.json.gz` if any of the generated CIF files cannot be converted to a `pymatgen.core.Structure` on line 235 (`all_gen_atoms_list = [Structure.from_file(file) for file in gen_atoms_files]`). The conversion may fail, for example, when two atoms are positioned very close together. Below is a generated CIF file that raised `ValueError: Invalid CIF file with no structures!` at `Structure.from_file(file)`, because Si1 and Si2 are too close.

```cif
data_image0
_chemical_formula_structural       AsBr4Pr8Si4
_chemical_formula_sum              "As1 Br4 Pr8 Si4"
_cell_length_a       8.632712147127318
_cell_length_b       8.634096403399067
_cell_length_c       8.93462931496471
_cell_angle_alpha    61.09685307073204
_cell_angle_beta     61.071439079404506
_cell_angle_gamma    59.971148441934695

_space_group_name_H-M_alt    "P 1"
_space_group_IT_number       1

loop_
  _space_group_symop_operation_xyz
  'x, y, z'

loop_
  _atom_site_type_symbol
  _atom_site_label
  _atom_site_symmetry_multiplicity
  _atom_site_fract_x
  _atom_site_fract_y
  _atom_site_fract_z
  _atom_site_occupancy
  As  As1       1.0  0.6330175399780273  0.6083690524101257  0.9208754897117614  1.0000
  Br  Br1       1.0  0.6329388618469238  0.10845752060413358  0.42075130343437195  1.0000
  Br  Br2       1.0  0.13327708840370178  0.6081749796867371  0.4209251999855041  1.0000
  Br  Br3       1.0  0.13322596251964575  0.1082707718014717  0.42066523432731623  1.0000
  Br  Br4       1.0  0.6330420970916748  0.6082326173782349  0.4207442104816436  1.0000
  Pr  Pr1       1.0  0.39660048484802246  0.36576297879219055  0.1328306496143341  1.0000
  Pr  Pr2       1.0  0.37349677085876465  0.34478163719177246  0.7063556909561157  1.0000
  Pr  Pr3       1.0  0.8703684210777284  0.341932326555252  0.7083711624145507  1.0000
  Pr  Pr4       1.0  0.8921607732772827  0.8713961839675903  0.13608235120773315  1.0000
  Pr  Pr5       1.0  0.3657117486000061  0.8468146920204163  0.709147036075592  1.0000
  Pr  Pr6       1.0  0.3959698975086212  0.8751904964447021  0.1329657733440399  1.0000
  Pr  Pr7       1.0  0.8698968291282654  0.8510026335716248  0.708305537700653  1.0000
  Pr  Pr8       1.0  0.9002637267112733  0.3700955212116241  0.13116395473480225  1.0000
  Si  Si1       1.0  0.6327558159828186  0.1083864495158195  0.920929729938507  1.0000
  Si  Si2       1.0  0.6327311992645264  0.10842001438140865  0.9208502769470215  1.0000
  Si  Si3       1.0  0.13282114267349243  0.1082785055041313  0.9207003116607666  1.0000
  Si  Si4       1.0  0.13300253450870528  0.608327031135559  0.9206736087799071  1.0000
```

# Solution
Use `try` and `except` to handle errors without stopping the entire program. At the end of the program, the total number of generated CIF files and the number of successfully converted CIF files are printed out.
