### PR TITLE
fix: Add PyTorch 2.6.0 compatibility with weights_only parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] - 2026-01-19
+
+### Changed
+- Updated pytorch-lightning requirement from `>=2.5.5` to `>=2.6.0` for weights_only parameter support
+
+### Fixed
+- Fixed checkpoint loading compatibility with PyTorch 2.6.0 by adding `weights_only=False` parameter
+- Resolved UnpicklingError when loading checkpoints with custom classes in PyTorch 2.6.0+
+
 ## [0.1.4] - 2026-01-19
 
 ### Added
@@ -45,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tutorial notebook with usage examples
 - PyPI distribution at https://pypi.org/project/chemeleon-dng/
 
+[0.1.5]: https://github.com/hspark1212/chemeleon-dng/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/hspark1212/chemeleon-dng/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/hspark1212/chemeleon-dng/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/hspark1212/chemeleon-dng/compare/v0.1.0...v0.1.2

--- a/chemeleon_dng/sample.py
+++ b/chemeleon_dng/sample.py
@@ -181,7 +181,9 @@ def sample(
     print(f"Using checkpoint path: {model_path}")
 
     # Load the diffusion module
-    dm = DiffusionModule.load_from_checkpoint(model_path, map_location=device)
+    dm = DiffusionModule.load_from_checkpoint(
+        model_path, map_location=device, weights_only=False
+    )
 
     # Validate the checkpoint’s task matches requested task
     assert (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "fire>=0.7.1",
     "pydantic>=2.12.0",
     "pymatgen>=2025.10.7",
-    "pytorch-lightning>=2.5.5",
+    "pytorch-lightning>=2.6.0",
     "torch>=2.1.0",
     "torch-geometric>=2.6.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chemeleon-dng"
-version = "0.1.4"
+version = "0.1.5"
 description = "Chemeleon framework for De Novo Generation (DNG) and Crystal Structure Prediction (CSP) tasks"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -52,7 +52,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! uv pip install chemeleon-dng==0.1.4 smact==3.2.0 mace-torch==0.3.14 torch-sim-atomistic==0.3.0 mp_api==0.45.13"
+    "! uv pip install chemeleon-dng==0.1.5 smact==3.2.0 mace-torch==0.3.14 torch-sim-atomistic==0.3.0 mp_api==0.45.13"
    ]
   },
   {

--- a/uv.lock
+++ b/uv.lock
@@ -260,7 +260,7 @@ requires-dist = [
     { name = "fire", specifier = ">=0.7.1" },
     { name = "pydantic", specifier = ">=2.12.0" },
     { name = "pymatgen", specifier = ">=2025.10.7" },
-    { name = "pytorch-lightning", specifier = ">=2.5.5" },
+    { name = "pytorch-lightning", specifier = ">=2.6.0" },
     { name = "torch", specifier = ">=2.1.0" },
     { name = "torch-geometric", specifier = ">=2.6.1" },
 ]
@@ -1757,7 +1757,7 @@ wheels = [
 
 [[package]]
 name = "pytorch-lightning"
-version = "2.5.5"
+version = "2.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fsspec", extra = ["http"] },
@@ -1769,9 +1769,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/16/78/bce84aab9a5b3b2e9d087d4f1a6be9b481adbfaac4903bc9daaaf09d49a3/pytorch_lightning-2.5.5.tar.gz", hash = "sha256:d6fc8173d1d6e49abfd16855ea05d2eb2415e68593f33d43e59028ecb4e64087", size = 643703, upload-time = "2025-09-05T16:01:18.313Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/d7/e3963d9669758f93b07941f4e2e82a394eb3d0980e29baa4764f3bad6689/pytorch_lightning-2.6.0.tar.gz", hash = "sha256:25b0d4f05e1f33b72be0920c34d0465777fe5f623228f9d6252b4b0f685d7037", size = 658853, upload-time = "2025-11-28T09:34:13.098Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/f6/99a5c66478f469598dee25b0e29b302b5bddd4e03ed0da79608ac964056e/pytorch_lightning-2.5.5-py3-none-any.whl", hash = "sha256:0b533991df2353c0c6ea9ca10a7d0728b73631fd61f5a15511b19bee2aef8af0", size = 832431, upload-time = "2025-09-05T16:01:16.234Z" },
+    { url = "https://files.pythonhosted.org/packages/77/eb/cc6dbfe70d15318dbce82674b1e8057cef2634ca9f9121a16b8a06c630db/pytorch_lightning-2.6.0-py3-none-any.whl", hash = "sha256:ee72cff4b8c983ecfaae8599382544bd5236d9eb300adc7dd305f359195f4e79", size = 849476, upload-time = "2025-11-28T09:34:11.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `weights_only=False` parameter to `load_from_checkpoint` for PyTorch 2.6.0 compatibility
- Update pytorch-lightning requirement from `>=2.5.5` to `>=2.6.0`
- Bump version to 0.1.5

## Changes
- **chemeleon_dng/sample.py**: Add `weights_only=False` to support loading checkpoints with custom classes
- **pyproject.toml**: Update pytorch-lightning requirement to >=2.6.0 and bump version to 0.1.5
- **CHANGELOG.md**: Document changes for version 0.1.5
- **tutorial.ipynb**: Update installation command to use version 0.1.5
- **uv.lock**: Sync with pytorch-lightning 2.6.0

## Background
PyTorch 2.6.0 changed the default value of `weights_only` from `False` to `True` in `torch.load`, causing `UnpicklingError` when loading checkpoints with custom classes like `DiffusionModule`. This fix explicitly sets `weights_only=False` to allow loading these checkpoints.

## Testing
- Tested locally with CSP task
- Tested in Google Colab